### PR TITLE
Corrected Indexing

### DIFF
--- a/getquote.php
+++ b/getquote.php
@@ -3,7 +3,7 @@ $fileContents = file_get_contents("quotes");
 
 $quote = explode("\n", $fileContents);
 
-$randomIndex = random_int(0, sizeof($quote));
+$randomIndex = random_int(0, sizeof($quote) - 1);
 
 if (isset($_GET['format']) && $_GET['format'] == 'json') {
 	header('Content-Type: application/json');


### PR DESCRIPTION
fixed the indexing issue that happened because of `sizeof($quote)` displaying the number of items instead of the max index